### PR TITLE
Add red for zero readyReplicas

### DIFF
--- a/k1s
+++ b/k1s
@@ -42,7 +42,8 @@ curl -N -s "http://localhost:$port$path?watch=true" |
     deployments|replicasets|statefulsets)
       spec=$(jq -r '.object.spec.replicas' <<<"$event")
       stat=$(jq -r '.object.status.readyReplicas // 0' <<<"$event")
-      [[ "$stat" = "$spec" ]] && info="$(c 32)($stat/$spec)$(c 0)" || info="$(c 33)($stat/$spec)$(c 0)" ;;
+      [[ "$stat" = "$spec" ]] && info="$(c 32)($stat/$spec)$(c 0)" || info="$(c 33)($stat/$spec)$(c 0)"
+      [[ "$stat" = "0" ]] && info="$(c 31)($stat/$spec)$(c 0)" ;;
     esac
     case $(jq -r .type <<<"$event") in
       ADDED) echo "$name $info" >>"$file" ;;


### PR DESCRIPTION
I felt it was necessary to color items that have zero readyReplicas red.

Problem:
On large helm releases or node upgrades I might be faced with a large amount of deployments (i.e. a wall of yellow text).

Solution:
Colorize resources that have zero replicas red to distinguish them as needing deeper inspection. Otherwise, I can assume at a glance that the deploy/rs/etc is progressing and is less concerning.

There might be instance where I might be interested in colorizing a pod red. Maybe if it's in *Backoff, but I'm not addressing that at this time.

Thanks!